### PR TITLE
Enable Otel in private docs

### DIFF
--- a/content/modules/ROOT/pages/module-private-docs.adoc
+++ b/content/modules/ROOT/pages/module-private-docs.adoc
@@ -85,7 +85,7 @@ In the terminal window that you opened earlier at the bottom of the editor, run 
 [.console-input]
 [source,bash,subs="+attributes,macros+"]
 ----
-./mvnw clean quarkus:dev -Dquarkus.otel.exporter.otlp.traces.endpoint=http://jaeger.parasol-app-{user}-dev.svc.cluster.local:4137
+./mvnw clean quarkus:dev -Dquarkus.otel.enabled=true -Dquarkus.otel.exporter.otlp.traces.endpoint=http://jaeger.parasol-app-{user}-dev.svc.cluster.local:4137
 ----
 
 This will download some dependencies and start the application in Quarkus Dev Mode.


### PR DESCRIPTION
Somehow the Otel integration got disabled in the private docs. This instructs the user to turn it on.